### PR TITLE
fix: prevent pool corruption from undefined boxId

### DIFF
--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -208,10 +208,11 @@ fastify.post('/api/v1/execute', async (request, reply) => {
     } finally {
         if (boxId !== undefined) {
             try {
-                await execAsync(`isolate --cleanup --cg --box-id=${boxId}`).catch(() => {});
-                pool.releaseBox(boxId);
+                await execAsync(`isolate --cleanup --cg --box-id=${boxId}`);
             } catch (cleanupError) {
-                fastify.log.error(`Failed to cleanup box ${boxId}: ${cleanupError}`);
+                fastify.log.error({ err: cleanupError }, `Failed to cleanup box ${boxId}`);
+            } finally {
+                pool.releaseBox(boxId);
             }
         }
     }

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -206,11 +206,13 @@ fastify.post('/api/v1/execute', async (request, reply) => {
         fastify.log.error(error);
         return reply.status(500).send({ error: 'Execution failed', details: error.message });
     } finally {
-        try {
-            await execAsync(`isolate --cleanup --cg --box-id=${boxId}`).catch(() => {});
-            pool.releaseBox(boxId);
-        } catch (cleanupError) {
-            fastify.log.error(`Failed to cleanup box ${boxId}: ${cleanupError}`);
+        if (boxId !== undefined) {
+            try {
+                await execAsync(`isolate --cleanup --cg --box-id=${boxId}`).catch(() => {});
+                pool.releaseBox(boxId);
+            } catch (cleanupError) {
+                fastify.log.error(`Failed to cleanup box ${boxId}: ${cleanupError}`);
+            }
         }
     }
 });


### PR DESCRIPTION
## Problem
If `pool.acquireBox()` throws an error (e.g., HTTP_429), the finally block 
still executes and calls `pool.releaseBox(boxId)` where `boxId` is undefined. 
This pushes undefined into the availableBoxIds array, corrupting the pool.

## Solution
Guard the releaseBox call with an undefined check.